### PR TITLE
feat(build): add Windows ARM64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,11 @@ jobs:
             platform: windows-amd64
             binary: rnr.exe
 
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            platform: windows-arm64
+            binary: rnr.exe
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -162,7 +167,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Verify build
-        if: matrix.target != 'aarch64-apple-darwin'
+        if: matrix.target != 'aarch64-apple-darwin' && matrix.target != 'aarch64-pc-windows-msvc'
         shell: bash
         run: |
           ./target/${{ matrix.target }}/release/${{ matrix.binary }} --version

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ deploy:
 | macOS | x86_64 | ✅ |
 | macOS | ARM64 (Apple Silicon) | ✅ |
 | Windows | x86_64 | ✅ |
+| Windows | ARM64 | ✅ |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `aarch64-pc-windows-msvc` target to the build matrix for Windows ARM64 support
- Skip binary verification for ARM64 targets (cannot run on x64 runners)
- Update README platform support table to include Windows ARM64

## Test plan

- [ ] Verify build workflow passes for all targets including new Windows ARM64
- [ ] Confirm Windows ARM64 artifact is uploaded
- [ ] Verify ARM64 targets skip the "Verify build" step