### PR TITLE
feat(cli): implement init command with platform selection

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -225,6 +225,157 @@ jobs:
           fi
           echo "✅ Nested task delegation passed"
 
+      # ==================== Init Command Tests ====================
+
+      - name: "Test: init --current-platform-only"
+        shell: bash
+        run: |
+          INIT_DIR=$(mktemp -d)
+          cd "$INIT_DIR"
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --current-platform-only
+
+          # Verify files were created
+          if [ ! -f ".rnr/config.yaml" ]; then
+            echo "ERROR: .rnr/config.yaml not created"
+            exit 1
+          fi
+          if [ ! -d ".rnr/bin" ]; then
+            echo "ERROR: .rnr/bin directory not created"
+            exit 1
+          fi
+          if [ ! -f "rnr.yaml" ]; then
+            echo "ERROR: rnr.yaml not created"
+            exit 1
+          fi
+          if [ ! -f "rnr" ]; then
+            echo "ERROR: rnr wrapper not created"
+            exit 1
+          fi
+          if [ ! -f "rnr.cmd" ]; then
+            echo "ERROR: rnr.cmd wrapper not created"
+            exit 1
+          fi
+
+          # Verify config has exactly one platform
+          PLATFORM_COUNT=$(grep -c "^-" .rnr/config.yaml || echo "0")
+          if [ "$PLATFORM_COUNT" != "1" ]; then
+            echo "ERROR: Expected 1 platform, got $PLATFORM_COUNT"
+            exit 1
+          fi
+
+          echo "✅ init --current-platform-only passed"
+          rm -rf "$INIT_DIR"
+
+      - name: "Test: init --platforms with multiple platforms"
+        shell: bash
+        run: |
+          INIT_DIR=$(mktemp -d)
+          cd "$INIT_DIR"
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --platforms linux-amd64,macos-arm64,windows-amd64
+
+          # Verify config has the right platforms
+          if ! grep -q "linux-amd64" .rnr/config.yaml; then
+            echo "ERROR: linux-amd64 not in config"
+            exit 1
+          fi
+          if ! grep -q "macos-arm64" .rnr/config.yaml; then
+            echo "ERROR: macos-arm64 not in config"
+            exit 1
+          fi
+          if ! grep -q "windows-amd64" .rnr/config.yaml; then
+            echo "ERROR: windows-amd64 not in config"
+            exit 1
+          fi
+
+          # Verify binaries exist
+          if [ ! -f ".rnr/bin/rnr-linux-amd64" ]; then
+            echo "ERROR: rnr-linux-amd64 binary not created"
+            exit 1
+          fi
+          if [ ! -f ".rnr/bin/rnr-macos-arm64" ]; then
+            echo "ERROR: rnr-macos-arm64 binary not created"
+            exit 1
+          fi
+          if [ ! -f ".rnr/bin/rnr-windows-amd64.exe" ]; then
+            echo "ERROR: rnr-windows-amd64.exe binary not created"
+            exit 1
+          fi
+
+          echo "✅ init --platforms passed"
+          rm -rf "$INIT_DIR"
+
+      - name: "Test: init --add-platform and --remove-platform"
+        shell: bash
+        run: |
+          INIT_DIR=$(mktemp -d)
+          cd "$INIT_DIR"
+
+          # First init with one platform
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --platforms linux-amd64
+
+          # Add a platform
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --add-platform macos-arm64
+
+          if ! grep -q "macos-arm64" .rnr/config.yaml; then
+            echo "ERROR: macos-arm64 not added to config"
+            exit 1
+          fi
+          if [ ! -f ".rnr/bin/rnr-macos-arm64" ]; then
+            echo "ERROR: rnr-macos-arm64 binary not created"
+            exit 1
+          fi
+
+          # Remove a platform
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --remove-platform linux-amd64
+
+          if grep -q "linux-amd64" .rnr/config.yaml; then
+            echo "ERROR: linux-amd64 should have been removed from config"
+            exit 1
+          fi
+          if [ -f ".rnr/bin/rnr-linux-amd64" ]; then
+            echo "ERROR: rnr-linux-amd64 binary should have been removed"
+            exit 1
+          fi
+
+          echo "✅ init --add-platform and --remove-platform passed"
+          rm -rf "$INIT_DIR"
+
+      - name: "Test: init --show-platforms"
+        shell: bash
+        run: |
+          INIT_DIR=$(mktemp -d)
+          cd "$INIT_DIR"
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --platforms linux-amd64,windows-amd64
+
+          OUTPUT=$($GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --show-platforms 2>&1)
+          if ! echo "$OUTPUT" | grep -q "linux-amd64"; then
+            echo "ERROR: --show-platforms should list linux-amd64"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -q "windows-amd64"; then
+            echo "ERROR: --show-platforms should list windows-amd64"
+            exit 1
+          fi
+
+          echo "✅ init --show-platforms passed"
+          rm -rf "$INIT_DIR"
+
+      - name: "Test: init refuses to remove last platform"
+        shell: bash
+        run: |
+          INIT_DIR=$(mktemp -d)
+          cd "$INIT_DIR"
+          $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --platforms linux-amd64
+
+          # Try to remove the only platform - should fail
+          if $GITHUB_WORKSPACE/tests/${{ matrix.binary }} init --remove-platform linux-amd64 2>&1; then
+            echo "ERROR: Should not be able to remove last platform"
+            exit 1
+          fi
+
+          echo "✅ init correctly refuses to remove last platform"
+          rm -rf "$INIT_DIR"
+
       # ==================== Error Cases ====================
 
       - name: "Test: nonexistent task (should fail)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ thiserror = "1"
 # Cross-platform support
 dirs = "5"
 
+# Interactive prompts
+dialoguer = "0.11"
+console = "0.15"
+
 # HTTP client for init/upgrade
 reqwest = { version = "0.12", features = ["blocking"], default-features = false, optional = true }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 /// A cross-platform task runner with zero setup
 #[derive(Parser, Debug)]
@@ -20,8 +20,35 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Initialize rnr in the current directory
-    Init,
+    Init(InitArgs),
 
     /// Upgrade rnr binaries to the latest version
     Upgrade,
+}
+
+#[derive(Args, Debug)]
+pub struct InitArgs {
+    /// Comma-separated list of platforms (e.g., linux-amd64,macos-arm64,windows-amd64)
+    #[arg(long, value_delimiter = ',')]
+    pub platforms: Option<Vec<String>>,
+
+    /// Include all available platforms
+    #[arg(long, conflicts_with_all = ["platforms", "current_platform_only"])]
+    pub all_platforms: bool,
+
+    /// Only include the current platform
+    #[arg(long, conflicts_with_all = ["platforms", "all_platforms"])]
+    pub current_platform_only: bool,
+
+    /// Add a platform to existing setup
+    #[arg(long, conflicts_with_all = ["platforms", "all_platforms", "current_platform_only", "remove_platform"])]
+    pub add_platform: Option<String>,
+
+    /// Remove a platform from existing setup
+    #[arg(long, conflicts_with_all = ["platforms", "all_platforms", "current_platform_only", "add_platform"])]
+    pub remove_platform: Option<String>,
+
+    /// Show currently configured platforms
+    #[arg(long)]
+    pub show_platforms: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod cli;
 mod commands;
 mod config;
+mod platform;
+mod rnr_config;
 mod runner;
 
 use anyhow::Result;
@@ -11,7 +13,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Init) => commands::init::run()?,
+        Some(Command::Init(args)) => commands::init::run(&args)?,
         Some(Command::Upgrade) => commands::upgrade::run()?,
         None => {
             if cli.list {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,148 @@
+//! Platform detection and definitions
+
+use std::fmt;
+
+/// All supported platforms
+pub const ALL_PLATFORMS: &[Platform] = &[
+    Platform::LinuxAmd64,
+    Platform::MacosAmd64,
+    Platform::MacosArm64,
+    Platform::WindowsAmd64,
+    Platform::WindowsArm64,
+];
+
+/// A supported platform
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Platform {
+    LinuxAmd64,
+    MacosAmd64,
+    MacosArm64,
+    WindowsAmd64,
+    WindowsArm64,
+}
+
+impl Platform {
+    /// Get the platform identifier string (e.g., "linux-amd64")
+    pub fn id(&self) -> &'static str {
+        match self {
+            Platform::LinuxAmd64 => "linux-amd64",
+            Platform::MacosAmd64 => "macos-amd64",
+            Platform::MacosArm64 => "macos-arm64",
+            Platform::WindowsAmd64 => "windows-amd64",
+            Platform::WindowsArm64 => "windows-arm64",
+        }
+    }
+
+    /// Get the binary filename for this platform
+    pub fn binary_name(&self) -> &'static str {
+        match self {
+            Platform::LinuxAmd64 => "rnr-linux-amd64",
+            Platform::MacosAmd64 => "rnr-macos-amd64",
+            Platform::MacosArm64 => "rnr-macos-arm64",
+            Platform::WindowsAmd64 => "rnr-windows-amd64.exe",
+            Platform::WindowsArm64 => "rnr-windows-arm64.exe",
+        }
+    }
+
+    /// Get the approximate binary size in bytes
+    pub fn size_bytes(&self) -> u64 {
+        match self {
+            Platform::LinuxAmd64 => 760 * 1024,
+            Platform::MacosAmd64 => 662 * 1024,
+            Platform::MacosArm64 => 608 * 1024,
+            Platform::WindowsAmd64 => 584 * 1024,
+            Platform::WindowsArm64 => 528 * 1024,
+        }
+    }
+
+    /// Get human-readable size string
+    pub fn size_display(&self) -> String {
+        let kb = self.size_bytes() / 1024;
+        format!("{} KB", kb)
+    }
+
+    /// Parse a platform from its identifier string
+    pub fn from_id(id: &str) -> Option<Platform> {
+        match id {
+            "linux-amd64" => Some(Platform::LinuxAmd64),
+            "macos-amd64" => Some(Platform::MacosAmd64),
+            "macos-arm64" => Some(Platform::MacosArm64),
+            "windows-amd64" => Some(Platform::WindowsAmd64),
+            "windows-arm64" => Some(Platform::WindowsArm64),
+            _ => None,
+        }
+    }
+
+    /// Detect the current platform
+    pub fn current() -> Option<Platform> {
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        return Some(Platform::LinuxAmd64);
+
+        #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+        return Some(Platform::MacosAmd64);
+
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        return Some(Platform::MacosArm64);
+
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        return Some(Platform::WindowsAmd64);
+
+        #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+        return Some(Platform::WindowsArm64);
+
+        #[allow(unreachable_code)]
+        None
+    }
+}
+
+impl fmt::Display for Platform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.id())
+    }
+}
+
+/// Calculate total size for a set of platforms
+pub fn total_size(platforms: &[Platform]) -> u64 {
+    platforms.iter().map(|p| p.size_bytes()).sum()
+}
+
+/// Format total size for display
+pub fn format_size(bytes: u64) -> String {
+    if bytes >= 1024 * 1024 {
+        format!("{:.2} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("{} KB", bytes / 1024)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_id_roundtrip() {
+        for platform in ALL_PLATFORMS {
+            let id = platform.id();
+            let parsed = Platform::from_id(id);
+            assert_eq!(parsed, Some(*platform));
+        }
+    }
+
+    #[test]
+    fn test_current_platform_is_known() {
+        // This test will pass on supported platforms
+        let current = Platform::current();
+        if let Some(p) = current {
+            assert!(ALL_PLATFORMS.contains(&p));
+        }
+    }
+
+    #[test]
+    fn test_binary_names() {
+        assert_eq!(Platform::LinuxAmd64.binary_name(), "rnr-linux-amd64");
+        assert_eq!(
+            Platform::WindowsAmd64.binary_name(),
+            "rnr-windows-amd64.exe"
+        );
+    }
+}

--- a/src/rnr_config.rs
+++ b/src/rnr_config.rs
@@ -1,0 +1,147 @@
+//! RNR configuration file management (.rnr/config.yaml)
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::platform::Platform;
+
+/// The rnr configuration directory name
+pub const RNR_DIR: &str = ".rnr";
+/// The rnr configuration file name
+pub const CONFIG_FILE: &str = "config.yaml";
+/// The binary directory name
+pub const BIN_DIR: &str = "bin";
+
+/// RNR configuration stored in .rnr/config.yaml
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RnrConfig {
+    /// Version of rnr that created this config
+    pub version: String,
+    /// List of configured platform identifiers
+    pub platforms: Vec<String>,
+}
+
+impl RnrConfig {
+    /// Create a new config with the given platforms
+    pub fn new(version: &str, platforms: &[Platform]) -> Self {
+        Self {
+            version: version.to_string(),
+            platforms: platforms.iter().map(|p| p.id().to_string()).collect(),
+        }
+    }
+
+    /// Load config from the default location
+    pub fn load() -> Result<Self> {
+        let path = config_path()?;
+        Self::load_from(&path)
+    }
+
+    /// Load config from a specific path
+    pub fn load_from(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read config: {}", path.display()))?;
+        let config: Self = serde_yaml::from_str(&content)
+            .with_context(|| format!("Failed to parse config: {}", path.display()))?;
+        Ok(config)
+    }
+
+    /// Save config to the default location
+    pub fn save(&self) -> Result<()> {
+        let path = config_path()?;
+        self.save_to(&path)
+    }
+
+    /// Save config to a specific path
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        let content = serde_yaml::to_string(self).context("Failed to serialize config")?;
+        fs::write(path, content)
+            .with_context(|| format!("Failed to write config: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Get the configured platforms
+    pub fn get_platforms(&self) -> Vec<Platform> {
+        self.platforms
+            .iter()
+            .filter_map(|id| Platform::from_id(id))
+            .collect()
+    }
+
+    /// Add a platform to the config
+    pub fn add_platform(&mut self, platform: Platform) {
+        let id = platform.id().to_string();
+        if !self.platforms.contains(&id) {
+            self.platforms.push(id);
+            self.platforms.sort();
+        }
+    }
+
+    /// Remove a platform from the config
+    pub fn remove_platform(&mut self, platform: Platform) {
+        let id = platform.id();
+        self.platforms.retain(|p| p != id);
+    }
+
+    /// Check if a platform is configured
+    pub fn has_platform(&self, platform: Platform) -> bool {
+        self.platforms.contains(&platform.id().to_string())
+    }
+}
+
+/// Get the path to .rnr directory
+pub fn rnr_dir() -> Result<PathBuf> {
+    let current = std::env::current_dir().context("Failed to get current directory")?;
+    Ok(current.join(RNR_DIR))
+}
+
+/// Get the path to .rnr/config.yaml
+pub fn config_path() -> Result<PathBuf> {
+    Ok(rnr_dir()?.join(CONFIG_FILE))
+}
+
+/// Get the path to .rnr/bin
+pub fn bin_dir() -> Result<PathBuf> {
+    Ok(rnr_dir()?.join(BIN_DIR))
+}
+
+/// Check if rnr is already initialized in the current directory
+pub fn is_initialized() -> Result<bool> {
+    let path = config_path()?;
+    Ok(path.exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_roundtrip() {
+        let platforms = vec![Platform::LinuxAmd64, Platform::MacosArm64];
+        let config = RnrConfig::new("0.1.0", &platforms);
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: RnrConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed.version, "0.1.0");
+        assert_eq!(parsed.platforms.len(), 2);
+    }
+
+    #[test]
+    fn test_add_remove_platform() {
+        let mut config = RnrConfig::new("0.1.0", &[Platform::LinuxAmd64]);
+
+        config.add_platform(Platform::MacosArm64);
+        assert!(config.has_platform(Platform::MacosArm64));
+
+        config.remove_platform(Platform::LinuxAmd64);
+        assert!(!config.has_platform(Platform::LinuxAmd64));
+    }
+}


### PR DESCRIPTION
## Summary

- Add interactive platform selection to init command
- Support non-interactive modes: `--all-platforms`, `--current-platform-only`, `--platforms <list>`
- Add platform management: `--add-platform`, `--remove-platform`, `--show-platforms`
- Create smart wrapper scripts that detect OS/architecture
- Add `.rnr/config.yaml` to track configured platforms

### New modules:
- `platform.rs`: Platform detection and definitions with sizes
- `rnr_config.rs`: `.rnr/config.yaml` management

### Binary sizes by platform:
| Platform | Size |
|----------|------|
| Linux x86_64 | 760 KB |
| macOS x86_64 | 662 KB |
| macOS ARM64 | 608 KB |
| Windows x86_64 | 584 KB |
| Windows ARM64 | 528 KB |

Closes #10
Closes #15

## Test plan

- [x] `cargo test` - 26 tests pass (including new platform/config tests)
- [x] `cargo clippy` - no warnings
- [x] Manual testing of all init options
- [x] E2E integration tests for init command added to workflow