### PR TITLE
docs(readme): update badges to for-the-badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Clone a repo. Run tasks. No setup required.**
 
-[![Build & Test](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml/badge.svg)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml)
-[![Integration Tests](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml/badge.svg)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build & Test](https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/rnr.cli/build.yml?style=for-the-badge&label=Build%20%26%20Test)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml)
+[![Integration Tests](https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/rnr.cli/integration-test.yml?style=for-the-badge&label=Integration%20Tests)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 ---
 


### PR DESCRIPTION
Update shields.io badges to use the for-the-badge style for consistency with other CodingWithCalvin repos.