### PR TITLE
docs(readme): fix badges and remove CI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Clone a repo. Run tasks. No setup required.**
 
-[![Build & Test](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml/badge.svg)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml)
-[![Integration Tests](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml/badge.svg)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml)
+[![Build & Test](https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/rnr.cli/build.yml?style=for-the-badge&label=Build%20%26%20Test)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/build.yml)
+[![Integration Tests](https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/rnr.cli/integration-test.yml?style=for-the-badge&label=Integration%20Tests)](https://github.com/CodingWithCalvin/rnr.cli/actions/workflows/integration-test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 ---


### PR DESCRIPTION
## Summary

- Use static shields.io badges with for-the-badge style (private repo cannot use dynamic badges)
- Remove CI non-interactive mode section from init documentation (nobody initializes a repo from CI)

## Changes

- Changed workflow badges from dynamic (shields.io GitHub API) to static badges that link to workflows
- Removed the "non-interactive mode for CI" section since init is meant for maintainers, not CI