### PR TITLE
fix(readme): use correct contributor markers for workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,8 @@ cargo run -- --help
 
 ## 👥 Contributors
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the README contributor section markers to match what the reusable contributors workflow expects.

Changed from:
- `<!-- ALL-CONTRIBUTORS-LIST:START ... -->`
- `<!-- ALL-CONTRIBUTORS-LIST:END -->`

To:
- `<!-- readme: contributors -start -->`
- `<!-- readme: contributors -end -->`