### PR TITLE
test(ci): enable network feature in integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,8 +62,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build release binary
-        # Build without network feature so init uses placeholder binaries (no releases exist yet)
-        run: cargo build --release --no-default-features --features parallel
+        run: cargo build --release
 
       - name: Copy binary to test location
         shell: bash


### PR DESCRIPTION
## Summary

Now that v0.1.0 is released, integration tests can download real binaries from GitHub releases instead of using placeholders.

## Changes

- Removed `--no-default-features --features parallel` from the build command
- Integration tests now verify real binary download functionality

Closes #41