### PR TITLE
fix(runner): preserve internal quotes in cmd strings on Windows

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -176,15 +176,7 @@ fn execute_step_def(
 fn execute_command(cmd: &str, work_dir: &Path, env: &HashMap<String, String>) -> Result<()> {
     println!("$ {}", cmd);
 
-    let mut command = if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/C", cmd]);
-        c
-    } else {
-        let mut c = Command::new("sh");
-        c.args(["-c", cmd]);
-        c
-    };
+    let mut command = build_shell_command(cmd);
 
     command.current_dir(work_dir);
     command.envs(env);
@@ -199,4 +191,26 @@ fn execute_command(cmd: &str, work_dir: &Path, env: &HashMap<String, String>) ->
     }
 
     Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn build_shell_command(cmd: &str) -> Command {
+    let mut c = Command::new("sh");
+    c.args(["-c", cmd]);
+    c
+}
+
+// On Windows, bypass Rust's MSVCRT-style arg escaping (which uses backslash
+// escapes that cmd.exe does not understand) and write the command line for
+// cmd.exe directly. `/S` makes cmd.exe deterministically strip exactly the
+// outermost pair of quotes, preserving any internal quotes — so a cmd like
+// `go build -ldflags="-s -w"` reaches its target program intact.
+#[cfg(target_os = "windows")]
+fn build_shell_command(cmd: &str) -> Command {
+    use std::os::windows::process::CommandExt;
+    let mut c = Command::new("cmd");
+    c.raw_arg("/S");
+    c.raw_arg("/C");
+    c.raw_arg(format!("\"{cmd}\""));
+    c
 }


### PR DESCRIPTION
## Summary
- On Windows, `Command::args(["/C", cmd])` runs Rust's MSVCRT-style arg escaping over the `cmd` string, converting internal `"` to `\"` — but cmd.exe doesn't understand backslash escapes, so the resulting command line is mistokenized by the time the target program receives it. A cmd like `go build -ldflags=\"-s -w\"` reached Go with `\"-s` and `-w\"` as separate argv entries.
- Switched to `raw_arg` (Windows-only) so we write the cmd.exe command line literally, and pass `/S` so cmd.exe deterministically strips only the outermost pair of quotes — internal quotes survive intact.
- Linux/macOS path is unchanged.

Resolves [#55](https://github.com/CodingWithCalvin/rnr.cli/issues/55)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Manual repro on Windows: `cmd /c echo -ldflags=\"-s -w\" foo` now prints `-ldflags=\"-s -w\" foo` (one token)
- [x] Sanity-checked simple cmds (`echo hello world`, `echo \"hello world\"`, multi-arg cmd with quoted args) still execute correctly